### PR TITLE
Allowing for users to optionally ensure their data is one connected component

### DIFF
--- a/GraphStructure.cpp
+++ b/GraphStructure.cpp
@@ -223,12 +223,8 @@ void GraphStructure<T>::ComputeNeighborhood(std::vector<int> &edgeIndices,
 template<typename T>
 GraphStructure<T>::GraphStructure(std::vector<T> &Xin, int rows, int cols,
                                   std::string graph, int maxN, T beta,
-                                  std::vector<int> &edgeIndices)
+                                  std::vector<int> &edgeIndices, bool connect)
 {
-  // This boolean flag dictates whether the dataset should be forced to be a
-  // single connected component. This feature might get deprecated or promoted
-  // to be exposed to the user, for now I will enforce that it does not happen
-  bool connect = false;
 
   int M = cols;
   int N = rows;
@@ -247,7 +243,7 @@ GraphStructure<T>::GraphStructure(std::vector<T> &Xin, int rows, int cols,
   std::vector< std::vector<T> > distances;
   int kmax = maxN;
 
-  ComputeNeighborhood(edgeIndices, edges, distances, graph, beta, kmax,connect);
+  ComputeNeighborhood(edgeIndices, edges, distances, graph, beta, kmax, connect);
 }
 
 template<typename T>

--- a/GraphStructure.h
+++ b/GraphStructure.h
@@ -76,7 +76,8 @@ class GraphStructure
    *        pruned by ngl)
    */
   GraphStructure(std::vector<T> &Xin, int rows, int cols, std::string graph,
-                 int maxN, T beta, std::vector<int> &edgeIndices);
+                 int maxN, T beta, std::vector<int> &edgeIndices,
+                 bool connect = false);
 
   /**
    * Returns the number of input dimensions in the associated dataset

--- a/nglpy/Graph.py
+++ b/nglpy/Graph.py
@@ -55,7 +55,7 @@ class Graph(nglGraph):
     Attributes:
         None
     """
-    def __init__(self, X, graph, maxN, beta, edges=None):
+    def __init__(self, X, graph, maxN, beta, edges=None, connect=False):
         """Initialization of the graph object. This will convert all of the
         passed in parameters into parameters the C++ implementation of NGL
         can understand and then issue an external call to that library.
@@ -68,6 +68,8 @@ class Graph(nglGraph):
                 single point in the dataset.
             beta (float): Only relevant when the graph type is a "beta skeleton"
             edges (list): A list of pre-defined edges to prune
+            connect (boolean): A flag specifying whether the data should
+                be a single connected component.
         """
 
         cols = 0
@@ -113,7 +115,7 @@ class Graph(nglGraph):
                 edgeList.append(edge[1])
             edges = vectorInt(edgeList)
 
-        super(Graph, self).__init__(vectorDouble(flattened_X), rows, cols, graph, maxN, beta, edges)
+        super(Graph, self).__init__(vectorDouble(flattened_X), rows, cols, graph, maxN, beta, edges, connect)
 
     def Neighbors(self, idx=None):
         """Returns the list of neighbors associated to a particular index in the

--- a/nglpy/__init__.py
+++ b/nglpy/__init__.py
@@ -1,35 +1,38 @@
- ##############################################################################
- # Software License Agreement (BSD License)                                   #
- #                                                                            #
- # Copyright 2014 University of Utah                                          #
- # Scientific Computing and Imaging Institute                                 #
- # 72 S Central Campus Drive, Room 3750                                       #
- # Salt Lake City, UT 84112                                                   #
- #                                                                            #
- # THE BSD LICENSE                                                            #
- #                                                                            #
- # Redistribution and use in source and binary forms, with or without         #
- # modification, are permitted provided that the following conditions         #
- # are met:                                                                   #
- #                                                                            #
- # 1. Redistributions of source code must retain the above copyright          #
- #    notice, this list of conditions and the following disclaimer.           #
- # 2. Redistributions in binary form must reproduce the above copyright       #
- #    notice, this list of conditions and the following disclaimer in the     #
- #    documentation and/or other materials provided with the distribution.    #
- # 3. Neither the name of the copyright holder nor the names of its           #
- #    contributors may be used to endorse or promote products derived         #
- #    from this software without specific prior written permission.           #
- #                                                                            #
- # THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR       #
- # IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES  #
- # OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.    #
- # IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,           #
- # INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT   #
- # NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  #
- # DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY      #
- # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT        #
- # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF   #
- # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.          #
- ##############################################################################
+##############################################################################
+# Software License Agreement (BSD License)                                   #
+#                                                                            #
+# Copyright 2014 University of Utah                                          #
+# Scientific Computing and Imaging Institute                                 #
+# 72 S Central Campus Drive, Room 3750                                       #
+# Salt Lake City, UT 84112                                                   #
+#                                                                            #
+# THE BSD LICENSE                                                            #
+#                                                                            #
+# Redistribution and use in source and binary forms, with or without         #
+# modification, are permitted provided that the following conditions         #
+# are met:                                                                   #
+#                                                                            #
+# 1. Redistributions of source code must retain the above copyright          #
+#    notice, this list of conditions and the following disclaimer.           #
+# 2. Redistributions in binary form must reproduce the above copyright       #
+#    notice, this list of conditions and the following disclaimer in the     #
+#    documentation and/or other materials provided with the distribution.    #
+# 3. Neither the name of the copyright holder nor the names of its           #
+#    contributors may be used to endorse or promote products derived         #
+#    from this software without specific prior written permission.           #
+#                                                                            #
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR       #
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES  #
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.    #
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,           #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT   #
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  #
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY      #
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT        #
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF   #
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.          #
+##############################################################################
 from .Graph import Graph
+
+__all__ = ['Graph']
+__version__ = '0.1.0'

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,24 @@
 """
 
 from setuptools import setup, Extension
+import re
+
+
+def get_property(prop, project):
+    """
+        Helper function for retrieving properties from a project's
+        __init__.py file
+        @In, prop, string representing the property to be retrieved
+        @In, project, string representing the project from which we will
+        retrieve the property
+        @Out, string, the value of the found property
+    """
+    result = re.search(r'{}\s*=\s*[\'"]([^\'"]*)[\'"]'.format(prop),
+                       open(project + '/__init__.py').read())
+    return result.group(1)
 
 FILES = ['ngl_wrap.cpp', 'GraphStructure.cpp', 'UnionFind.cpp']
-VERSION = '0.2.6'
+VERSION = get_property('__version__', 'nglpy')
 
 def long_description():
     """ Reads the README.md file and extracts the portion tagged between
@@ -73,7 +88,9 @@ setup(name='nglpy',
       test_suite='nglpy.tests',
       url = 'https://github.com/maljovec/nglpy',
       download_url = 'https://github.com/maljovec/nglpy/archive/'+VERSION+'.tar.gz',
-      keywords = ['geometry', 'neighborhood', 'empty region graph', 'neighborhood graph library'],
+      keywords = ['geometry', 'neighborhood', 'empty region graph',
+                  'neighborhood graph library', 'beta skeleton',
+                  'relative neighbor', 'Gabriel graph'],
       ## Consult here: https://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
             'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This exposes the `connect` boolean flag to the user. The default value is false, but if set to true on the constructor for a graph object, the code will ensure that the returned edge list represents a single connected component, by connecting the closest two points between every pair of separate connected components in the data.